### PR TITLE
Disable test that is too sensitive to very small differences in function sin().

### DIFF
--- a/tests/testthat/test-step.plugin.R
+++ b/tests/testthat/test-step.plugin.R
@@ -4,7 +4,7 @@ test_that("Plug-in step handles inputs well", {
 
 test_that("Plug-in step checks for small truncation errors", {
   expect_equal(step.plugin(sin, pi/3)$exitcode, 0)
-  expect_equal(step.plugin(sin, pi/4)$exitcode, 1)
+#  expect_equal(step.plugin(sin, pi/4)$exitcode, 1)
   expect_equal(step.plugin(sin, pi/2)$exitcode, 1)
 })
 


### PR DESCRIPTION
This patch simply disables the test, but it might be better to have a closer look at whether this and similar expectations are reasonable.

The problem with the test is that it makes the package fail its checks on Windows Server 2022 with mingw-w64 v12, due to very small differences in the results of C math function sin(). All the differences that matter for the test to fail compared to mingw-w64 v11 are within 1 ULP (and they are within 1 ULP from the correctly rounded result). This suggests the test is overly-sensitive to its inputs (the C standard does not mandate a specific accuracy limit for Math functions).

For some other calls to sin() made during the package checks, that however do not make any tests to fail here, the differences in the results of sin() are much bigger, and certainly not reasonable, but they are to the better: UCRT (mingw-w64 v12) is more precise, it is mingw-w64 v11 with its internal implementation of sin() that is far off. This would make it even less realistic reporting this as a bug in mingw-w64 v12.

(the problem is not reproducible on Windows 10 I have access to - there are very small differences in the UCRT results there and on Windows Server 2022, to the point that with mingw-w64 v12, the test passes on my Windows 10).
